### PR TITLE
Decrypt mw6 gscobj

### DIFF
--- a/src/Parasyte/CoDMW4Handler.cpp
+++ b/src/Parasyte/CoDMW4Handler.cpp
@@ -521,6 +521,22 @@ bool ps::CoDMW4Handler::LoadFastFile(const std::string& ffName, FastFile* parent
 	return true;
 }
 
+char* ps::CoDMW4Handler::DecryptString(char* str)
+{
+	if (!ps::CoDMW4Internal::DecryptString)
+	{
+		throw std::exception("Can't find DecryptString function.");
+	}
+
+	if ((*str & 0xC0) == 0x80)
+	{
+		const char* dstr = ps::CoDMW4Internal::DecryptString(str);
+		memcpy(str, dstr, strlen(dstr) + 1);
+	}
+
+	return str;
+}
+
 bool ps::CoDMW4Handler::CleanUp()
 {
 	ps::CoDMW4Internal::FFDecompressor = nullptr;

--- a/src/Parasyte/CoDMW4Handler.h
+++ b/src/Parasyte/CoDMW4Handler.h
@@ -28,6 +28,9 @@ namespace ps
 		// Loads the fast file with the given name, along with any children such as localized files.
 		bool LoadFastFile(const std::string& ffName, FastFile* parent, BitFlags<FastFileFlags> flags) override;
 
+		// Decrypt string
+		char* DecryptString(char* str) override;
+
 		// Cleans up any left over data after calling load.
 		bool CleanUp() override;
 	};

--- a/src/Parasyte/CoDMW5Handler.cpp
+++ b/src/Parasyte/CoDMW5Handler.cpp
@@ -653,6 +653,22 @@ bool ps::CoDMW5Handler::LoadFastFile(const std::string& ffName, FastFile* parent
 	return true;
 }
 
+char* ps::CoDMW5Handler::DecryptString(char* str)
+{
+	if (!ps::CoDMW5Internal::DecryptString)
+	{
+		throw std::exception("Can't find DecryptString function.");
+	}
+
+	if ((*str & 0xC0) == 0x80)
+	{
+		const char* dstr = ps::CoDMW5Internal::DecryptString(ps::CoDMW5Internal::StrDecryptBuffer.get(), ps::CoDMW5Internal::StrDecryptBufferSize, str, nullptr);
+		memcpy(str, dstr, strlen(dstr) + 1);
+	}
+
+	return str;
+}
+
 bool ps::CoDMW5Handler::CleanUp()
 {
 	ps::CoDMW5Internal::FFDecompressor = nullptr;

--- a/src/Parasyte/CoDMW5Handler.h
+++ b/src/Parasyte/CoDMW5Handler.h
@@ -24,6 +24,8 @@ namespace ps
 		bool LoadFastFile(const std::string& ffName, FastFile* parent, BitFlags<FastFileFlags> flags) override;
 		// Cleans up any left over data after calling load.
 		bool CleanUp() override;
+		// Decrypt string
+		char* DecryptString(char* str) override;
 		// Gets a file path for the provided fast file name with the current flags and directory.
 		std::string GetFileName(const std::string& name) override;
 	};

--- a/src/Parasyte/CoDMW6Handler.cpp
+++ b/src/Parasyte/CoDMW6Handler.cpp
@@ -1015,6 +1015,22 @@ bool ps::CoDMW6Handler::CleanUp()
 	return false;
 }
 
+char* ps::CoDMW6Handler::DecryptString(char* str)
+{
+	if (!ps::CoDMW6Internal::DecryptString)
+	{
+		throw std::exception("Can't find DecryptString function.");
+	}
+
+	if ((*str & 0xC0) == 0x80)
+	{
+		const char* dstr = ps::CoDMW6Internal::DecryptString(ps::CoDMW6Internal::StrDecryptBuffer.get(), ps::CoDMW6Internal::StrDecryptBufferSize, str, nullptr);
+		memcpy(str, dstr, strlen(dstr) + 1);
+	}
+
+	return str;
+}
+
 std::string ps::CoDMW6Handler::GetFileName(const std::string& name)
 {
 	return (CurrentConfig->FilesDirectory.empty()) ? (name) : (CurrentConfig->FilesDirectory + "/" + name);

--- a/src/Parasyte/CoDMW6Handler.cpp
+++ b/src/Parasyte/CoDMW6Handler.cpp
@@ -349,6 +349,137 @@ namespace ps::CoDMW6Internal
 			}
 			memcpy(*(char**)(result->Header + 8), str, strlen(str) + 1);
 		}
+
+		if (assetType == 0x45 && DecryptString != nullptr)
+		{
+			struct GSC_USEANIMTREE_ITEM
+			{
+				uint32_t num_address;
+				uint32_t address;
+			};
+
+			struct GSC_ANIMTREE_ITEM
+			{
+				uint32_t num_address;
+				uint32_t address_str1;
+				uint32_t address_str2;
+			};
+			struct GSC_STRINGTABLE_ITEM
+			{
+				uint32_t string;
+				uint8_t num_address;
+				uint8_t type;
+				uint16_t pad;
+			};
+
+			struct GSC_OBJ_8B
+			{
+				uint8_t magic[8];
+				uint64_t name;
+				uint16_t unk10;
+				uint16_t animtree_use_count;
+				uint16_t animtree_count;
+				uint16_t devblock_string_count;
+				uint16_t export_count;
+				uint16_t fixup_count;
+				uint16_t unk1C;
+				uint16_t imports_count;
+				uint16_t includes_count;
+				uint16_t unk22;
+				uint16_t string_count;
+				uint16_t unk26;
+				uint32_t checksum;
+				uint32_t animtree_use_offset;
+				uint32_t animtree_offset;
+				uint32_t cseg_offset;
+				uint32_t cseg_size;
+				uint32_t devblock_string_offset;
+				uint32_t export_offset;
+				uint32_t fixup_offset;
+				uint32_t size1;
+				uint32_t import_table;
+				uint32_t include_table;
+				uint32_t size2;
+				uint32_t string_table;
+			};
+
+			struct GscObjEntry
+			{
+				uint64_t name;
+				int len;
+				int padc;
+				GSC_OBJ_8B* buffer;
+			};
+
+			const auto gscObj = (GscObjEntry*)result->Header;
+
+			if (gscObj->len && gscObj->buffer && *(uint64_t*)gscObj->buffer == 0xa0d4353478b)
+			{
+				// encrypted script (VM 8B)
+				GSC_OBJ_8B* script = gscObj->buffer;
+
+
+				// string table
+				GSC_STRINGTABLE_ITEM* strings = reinterpret_cast<GSC_STRINGTABLE_ITEM*>(script->magic + script->string_table);
+
+				for (int j = 0; j < script->string_count; j++)
+				{
+					char* str = (char*)(script->magic + strings->string);
+
+					if ((*str & 0xC0) == 0x80)
+					{
+						const char* dstr = DecryptString(ps::CoDMW6Internal::StrDecryptBuffer.get(), ps::CoDMW6Internal::StrDecryptBufferSize, str, nullptr);
+						memcpy(str, dstr, strlen(dstr) + 1);
+					}
+
+					strings = reinterpret_cast<GSC_STRINGTABLE_ITEM*>(reinterpret_cast<uint32_t*>(&strings[1]) + strings->num_address);
+				}
+
+				// animtree tables
+
+				GSC_ANIMTREE_ITEM* animt = reinterpret_cast<GSC_ANIMTREE_ITEM*>(script->magic + script->animtree_offset);
+
+				for (int j = 0; j < script->animtree_count; j++)
+				{
+					{
+						char* str = (char*)(script->magic + animt->address_str1);
+
+						if ((*str & 0xC0) == 0x80)
+						{
+							const char* dstr = DecryptString(ps::CoDMW6Internal::StrDecryptBuffer.get(), ps::CoDMW6Internal::StrDecryptBufferSize, str, nullptr);
+							memcpy(str, dstr, strlen(dstr) + 1);
+						}
+					}
+					{
+						char* str = (char*)(script->magic + animt->address_str2);
+
+						if ((*str & 0xC0) == 0x80)
+						{
+							const char* dstr = DecryptString(ps::CoDMW6Internal::StrDecryptBuffer.get(), ps::CoDMW6Internal::StrDecryptBufferSize, str, nullptr);
+							memcpy(str, dstr, strlen(dstr) + 1);
+						}
+					}
+
+					animt = reinterpret_cast<GSC_ANIMTREE_ITEM*>(reinterpret_cast<uint32_t*>(&animt[1]) + animt->num_address);
+				}
+
+				GSC_USEANIMTREE_ITEM* animtu = reinterpret_cast<GSC_USEANIMTREE_ITEM*>(script->magic + script->animtree_use_offset);
+
+				for (int j = 0; j < script->animtree_use_count; j++) {
+					char* str = (char*)(script->magic + animtu->address);
+
+					if ((*str & 0xC0) == 0x80)
+					{
+						const char* dstr = DecryptString(ps::CoDMW6Internal::StrDecryptBuffer.get(), ps::CoDMW6Internal::StrDecryptBufferSize, str, nullptr);
+						memcpy(str, dstr, strlen(dstr) + 1);
+					}
+
+					animtu = reinterpret_cast<GSC_USEANIMTREE_ITEM*>(reinterpret_cast<uint32_t*>(&animtu[1]) + animtu->num_address);
+				}
+
+			}
+		}
+
 // #else
 // 		switch (assetType)
 // 		{

--- a/src/Parasyte/CoDMW6Handler.h
+++ b/src/Parasyte/CoDMW6Handler.h
@@ -26,6 +26,8 @@ namespace ps
 		bool DumpAliases() override;
 		// Cleans up any left over data after calling load.
 		bool CleanUp() override;
+		// Decrypt string
+		char* DecryptString(char* str) override;
 		// Gets a file path for the provided fast file name with the current flags and directory.
 		std::string GetFileName(const std::string& name) override;
 	};

--- a/src/Parasyte/CoDVGHandler.cpp
+++ b/src/Parasyte/CoDVGHandler.cpp
@@ -515,6 +515,22 @@ bool ps::CoDVGHandler::LoadFastFile(const std::string& ffName, FastFile* parent,
 	return true;
 }
 
+char* ps::CoDVGHandler::DecryptString(char* str)
+{
+	if (!ps::CoDVGInternal::DecryptString)
+	{
+		throw std::exception("Can't find DecryptString function.");
+	}
+
+	if ((*str & 0xC0) == 0x80)
+	{
+		const char* dstr = ps::CoDVGInternal::DecryptString(ps::CoDVGInternal::StrDecryptBuffer.get(), ps::CoDVGInternal::StrDecryptBufferSize, str);
+		memcpy(str, dstr, strlen(dstr) + 1);
+	}
+
+	return str;
+}
+
 bool ps::CoDVGHandler::CleanUp()
 {
 	ps::CoDVGInternal::FFDecompressor = nullptr;

--- a/src/Parasyte/CoDVGHandler.h
+++ b/src/Parasyte/CoDVGHandler.h
@@ -22,6 +22,8 @@ namespace ps
 		bool IsValid(const std::string& param) override;
 		// Loads the fast file with the given name, along with any children such as localized files.
 		bool LoadFastFile(const std::string& ffName, FastFile* parent, BitFlags<FastFileFlags> flags) override;
+		// Decrypt string
+		char* DecryptString(char* str) override;
 		// Cleans up any left over data after calling load.
 		bool CleanUp() override;
 	};

--- a/src/Parasyte/DecryptScriptCommand.h
+++ b/src/Parasyte/DecryptScriptCommand.h
@@ -1,0 +1,15 @@
+#pragma once
+#include "Command.h"
+
+namespace ps
+{
+	class DecryptScriptCommand : public Command
+	{
+	public:
+		// Inits the command.
+		DecryptScriptCommand();
+
+		// Executes the command
+		void Execute(ps::CommandParser& parser) const;
+	};
+}

--- a/src/Parasyte/DecryptScriptsCommand.cpp
+++ b/src/Parasyte/DecryptScriptsCommand.cpp
@@ -1,0 +1,305 @@
+#include "pch.h"
+#include "DecryptScriptCommand.h"
+#include "Utility.h"
+#include "FileSystem.h"
+#include "FileHandle.h"
+
+ps::DecryptScriptCommand::DecryptScriptCommand() : Command(
+	"decryptscript",
+	"Decrypt compiled GSC scripts.",
+	"This command decrypts a gscobj dump using the loaded game decryption.",
+	"decryptscript \"C:\\gscobj_dump\" \"C:\\gscobj_dump_decrypted\"",
+	true)
+{
+}
+
+void ps::DecryptScriptCommand::Execute(ps::CommandParser& parser) const
+{
+	ps::Parasyte::VerifyHandler();
+
+
+	const std::string& gscsPath = parser.Next();
+	const std::string& gscsOutputPath = parser.Next();
+
+	auto* handler = ps::Parasyte::GetCurrentHandler();
+
+	ps::log::Print("MAIN", "Decrypting: %s into %s...", gscsPath.c_str(), gscsOutputPath.c_str());
+
+	auto fsi = ps::FileSystem::Open(gscsPath);
+	auto fso = ps::FileSystem::Open(gscsOutputPath);
+
+	std::filesystem::create_directories(gscsOutputPath);
+
+	fsi->EnumerateFiles("", "*.gscc", false, [handler, &fsi, &fso, &gscsOutputPath](const std::string& fileName, const size_t size)
+	{
+		if (size <= sizeof(uint64_t))
+		{
+			return; // too small
+		}
+
+		ps::FileHandle ffHandle{ fsi->OpenFile(fileName, "r"), fsi.get() };
+
+		if (!ffHandle.IsValid())
+		{
+			ps::log::Print("WARNING", "Error when reading", fileName.c_str());
+			return;
+		}
+
+
+		auto buff{ ffHandle.ReadArray<uint8_t>(size) };
+
+		ffHandle.Close();
+
+		uint64_t magic{ *(uint64_t*)buff.get() };
+
+		struct GSC_USEANIMTREE_ITEM
+		{
+			uint32_t num_address;
+			uint32_t address;
+		};
+
+		struct GSC_ANIMTREE_ITEM
+		{
+			uint32_t num_address;
+			uint32_t address_str1;
+			uint32_t address_str2;
+		};
+		struct GSC_STRINGTABLE_ITEM
+		{
+			uint32_t string;
+			uint8_t num_address;
+			uint8_t type;
+			uint16_t pad;
+		};
+
+
+		switch (magic)
+		{
+		case 0xa0d4353478a: // MWIII 8A
+			break; // nothing to do, can be present due to a remnant in the mwiii fastfiles
+		case 0x37000a0d43534780: // CW 37
+		{
+			struct GscObjCW37
+			{
+				uint8_t magic[8];
+				uint32_t crc;
+				uint32_t pad0c;
+				uint64_t name;
+				uint32_t includes_table;
+				uint16_t string_count;
+				uint16_t export_count;
+				uint32_t cseg_offset;
+				uint32_t string_table;
+				uint16_t imports_count;
+				uint16_t fixup_count;
+				uint32_t devblock_string_table;
+				uint32_t exports_tables;
+				uint32_t imports_offset;
+				uint16_t globalvar_count;
+				uint16_t unk3a;
+				uint32_t fixup_offset;
+				uint32_t globalvar_offset;
+				uint32_t file_size;
+				uint16_t unk48;
+				uint16_t devblock_string_count;
+				uint32_t cseg_size;
+				uint16_t includes_count;
+				uint16_t unk52;
+				uint32_t unk54;
+			};
+			GscObjCW37* script = (GscObjCW37*)buff.get();
+
+
+			// string table
+			GSC_STRINGTABLE_ITEM* strings = reinterpret_cast<GSC_STRINGTABLE_ITEM*>(script->magic + script->string_table);
+
+			for (int j = 0; j < script->string_count; j++)
+			{
+				char* str = (char*)(script->magic + strings->string);
+
+				handler->DecryptString(str);
+
+				strings = reinterpret_cast<GSC_STRINGTABLE_ITEM*>(reinterpret_cast<uint32_t*>(&strings[1]) + strings->num_address);
+			}
+			break;
+		}
+		case 0x38000a0d43534780: // CW 38
+		{
+			struct GscObjCW38 {
+				uint8_t magic[8];
+				int32_t crc;
+				int32_t pad0c;
+				uint64_t name;
+				uint16_t string_count;
+				uint16_t exports_count;
+				uint16_t imports_count;
+				uint16_t unk1e;
+				uint16_t globalvar_count;
+				uint16_t unk22;
+				uint16_t includes_count;
+				uint16_t devblock_string_count;
+				uint32_t devblock_string_offset;
+				uint32_t cseg_offset;
+				uint32_t string_table;
+				uint32_t includes_table;
+				uint32_t exports_tables;
+				uint32_t import_tables;
+				uint32_t unk40;
+				uint32_t globalvar_offset;
+				uint32_t file_size;
+				uint32_t unk4c;
+				uint32_t cseg_size;
+				uint32_t unk54;
+			};
+			GscObjCW38* script = (GscObjCW38*)buff.get();
+
+
+			// string table
+			GSC_STRINGTABLE_ITEM* strings = reinterpret_cast<GSC_STRINGTABLE_ITEM*>(script->magic + script->string_table);
+
+			for (int j = 0; j < script->string_count; j++)
+			{
+				char* str = (char*)(script->magic + strings->string);
+
+				handler->DecryptString(str);
+
+				strings = reinterpret_cast<GSC_STRINGTABLE_ITEM*>(reinterpret_cast<uint32_t*>(&strings[1]) + strings->num_address);
+			}
+			break;
+		}
+		case 0xa0d4353478b: // MWIII 8B
+		{
+			struct GscObj23
+			{
+				uint8_t magic[8];
+				uint64_t name;
+				uint16_t unk10;
+				uint16_t animtree_use_count;
+				uint16_t animtree_count;
+				uint16_t devblock_string_count;
+				uint16_t export_count;
+				uint16_t fixup_count;
+				uint16_t unk1C;
+				uint16_t imports_count;
+				uint16_t includes_count;
+				uint16_t unk22;
+				uint16_t string_count;
+				uint16_t unk26;
+				uint32_t checksum;
+				uint32_t animtree_use_offset;
+				uint32_t animtree_offset;
+				uint32_t cseg_offset;
+				uint32_t cseg_size;
+				uint32_t devblock_string_offset;
+				uint32_t export_offset;
+				uint32_t fixup_offset;
+				uint32_t size1;
+				uint32_t import_table;
+				uint32_t include_table;
+				uint32_t size2;
+				uint32_t string_table;
+			};
+
+			GscObj23* script = (GscObj23*)buff.get();
+
+
+			// string table
+			GSC_STRINGTABLE_ITEM* strings = reinterpret_cast<GSC_STRINGTABLE_ITEM*>(script->magic + script->string_table);
+
+			for (int j = 0; j < script->string_count; j++)
+			{
+				char* str = (char*)(script->magic + strings->string);
+
+				handler->DecryptString(str);
+
+				strings = reinterpret_cast<GSC_STRINGTABLE_ITEM*>(reinterpret_cast<uint32_t*>(&strings[1]) + strings->num_address);
+			}
+
+			// animtree tables
+
+			GSC_ANIMTREE_ITEM* animt = reinterpret_cast<GSC_ANIMTREE_ITEM*>(script->magic + script->animtree_offset);
+
+			for (int j = 0; j < script->animtree_count; j++)
+			{
+				handler->DecryptString((char*)(script->magic + animt->address_str1));
+				handler->DecryptString((char*)(script->magic + animt->address_str2));
+
+				animt = reinterpret_cast<GSC_ANIMTREE_ITEM*>(reinterpret_cast<uint32_t*>(&animt[1]) + animt->num_address);
+			}
+
+			GSC_USEANIMTREE_ITEM* animtu = reinterpret_cast<GSC_USEANIMTREE_ITEM*>(script->magic + script->animtree_use_offset);
+
+			for (int j = 0; j < script->animtree_use_count; j++) {
+				handler->DecryptString((char*)(script->magic + animtu->address));
+
+				animtu = reinterpret_cast<GSC_USEANIMTREE_ITEM*>(reinterpret_cast<uint32_t*>(&animtu[1]) + animtu->num_address);
+			}
+
+			break;
+		}
+		case 0xa0d43534706: // Black Ops 6
+		{
+			struct GscObj24 {
+				uint8_t magic[8];
+				uint64_t name;
+				uint16_t unk10;
+				uint16_t animtree_use_count;
+				uint16_t animtree_count;
+				uint16_t devblock_string_count;
+				uint16_t export_count;
+				uint16_t fixup_count;
+				uint16_t unk1C;
+				uint16_t imports_count;
+				uint16_t includes_count;
+				uint16_t string_count;
+				uint16_t unk24;
+				uint16_t unk26;
+				uint32_t checksum;
+				uint32_t animtree_use_offset;
+				uint32_t animtree_offset;
+				uint32_t cseg_offset;
+				uint32_t cseg_size;
+				uint32_t devblock_string_offset;
+				uint32_t export_offset;
+				uint32_t fixup_offset;
+				uint32_t size1;
+				uint32_t import_table;
+				uint32_t include_table;
+				uint32_t string_table;
+				uint32_t size2;
+				uint32_t unk5C;
+			};
+
+			GscObj24* script = (GscObj24*)buff.get();
+
+			// string table
+			GSC_STRINGTABLE_ITEM* strings = reinterpret_cast<GSC_STRINGTABLE_ITEM*>(script->magic + script->string_table);
+
+			for (int j = 0; j < script->string_count; j++)
+			{
+				handler->DecryptString((char*)(script->magic + strings->string));
+				strings = reinterpret_cast<GSC_STRINGTABLE_ITEM*>(reinterpret_cast<uint32_t*>(&strings[1]) + strings->num_address);
+			}
+
+		}
+			break;
+		default:
+			ps::log::Print("WARNING", "Unknown magic %llx for file %s.", magic, fileName.c_str());
+			return;
+		}
+
+		std::ofstream os{ std::format("{}/{}", gscsOutputPath, fileName), std::ios::binary };
+
+		if (!os)
+		{
+			ps::log::Print("WARNING", "Error when writing %s 0x%llx", fileName.c_str(), fso->GetLastError());
+			return;
+		}
+
+		os.write((const char*)buff.get(), size);
+
+		os.close();
+	});
+}
+
+PS_CINIT(ps::Command, ps::DecryptScriptCommand, ps::Command::GetCommands());

--- a/src/Parasyte/GameHandler.cpp
+++ b/src/Parasyte/GameHandler.cpp
@@ -543,6 +543,11 @@ bool ps::GameHandler::CopyDependencies()
 	return true;
 }
 
+char* ps::GameHandler::DecryptString(char* str)
+{
+	return str; // no decryption by default
+}
+
 std::list<std::unique_ptr<ps::GameHandler>>& ps::GameHandler::GetHandlers()
 {
 	static std::list<std::unique_ptr<ps::GameHandler>> handlers;

--- a/src/Parasyte/GameHandler.h
+++ b/src/Parasyte/GameHandler.h
@@ -128,6 +128,8 @@ namespace ps
 		virtual bool ResolvePatterns();
 		// Copies dependencies.
 		virtual bool CopyDependencies();
+		// Decrypt a string
+		virtual char* DecryptString(char* str);
 
 		// Gets the list of handlers.
 		static std::list<std::unique_ptr<GameHandler>>& GetHandlers();

--- a/src/Parasyte/Parasyte.vcxproj
+++ b/src/Parasyte/Parasyte.vcxproj
@@ -202,6 +202,7 @@
     <ClInclude Include="Command.h" />
     <ClInclude Include="CommandParser.h" />
     <ClInclude Include="Decompressor.h" />
+    <ClInclude Include="DecryptScriptCommand.h" />
     <ClInclude Include="DeinitCommand.h" />
     <ClInclude Include="DisableVerbosityCommand.h" />
     <ClInclude Include="DumpCommand.h" />
@@ -293,6 +294,7 @@
     <ClCompile Include="Command.cpp" />
     <ClCompile Include="CommandParser.cpp" />
     <ClCompile Include="Decompressor.cpp" />
+    <ClCompile Include="DecryptScriptsCommand.cpp" />
     <ClCompile Include="DeinitCommand.cpp" />
     <ClCompile Include="DisableVerbosityCommand.cpp" />
     <ClCompile Include="DumpCommand.cpp" />

--- a/src/Parasyte/Parasyte.vcxproj.filters
+++ b/src/Parasyte/Parasyte.vcxproj.filters
@@ -309,6 +309,9 @@
     <ClInclude Include="CoDBO3Handler.h">
       <Filter>Header Files\Handlers</Filter>
     </ClInclude>
+    <ClInclude Include="DecryptScriptCommand.h">
+      <Filter>Header Files\Commands</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">
@@ -571,6 +574,9 @@
     </ClCompile>
     <ClCompile Include="CoDBO3Handler.cpp">
       <Filter>Source Files\Handlers</Filter>
+    </ClCompile>
+    <ClCompile Include="DecryptScriptsCommand.cpp">
+      <Filter>Source Files\Commands</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Hello,

Like said in the title, this code is simply decrypting the strings inside the gscobj pool. I have also checked the scriptbundle pool, but unlike in bo4/cw, the strings are encrypted.

For a performance perspective, with a simple load of the server and common fastfiles, ~3000 scripts were loaded with ~60000 decrypted strings. I didn't notice more wait time while loading them.

I apologize, I am not used to this codebase yet, maybe it wasn't the best way to add this feature, but I am open to replace it.

Edit:

I added a new command to decrypt the gscobj using the decrypt string function of the current game

```pwsh
decryptscript "C:\gscobj_dump" "C:\gscobj_dump_decrypted"
```

To do so, I added a virtual function to the base handler class

```cpp
// Decrypt a string
virtual char* DecryptString(char* str);
```

It decrypts a string into itself and return it.

This command add is independent of the gscobj pool decryption and separated in another commit.